### PR TITLE
add nn::fs::MountCacheStorage

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3269,6 +3269,15 @@ pub mod root {
                     filepath: *const libc::c_char,
                 ) -> root::Result;
             }
+            extern "C" {
+                #[link_name = "_ZN2nn2fs17MountCacheStorageEPKc"]
+                pub fn MountCacheStorage(mount_point: *const libc::c_char) -> root::Result;
+            }
+            pub fn MountCache<S: AsRef<str>>(mount_point: S) -> root::Result {
+                unsafe {
+                    MountCacheStorage([mount_point.as_ref(), "\0"].concat().as_ptr())
+                }
+            }
         }
         pub mod ro {
             #[allow(unused_imports)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3273,7 +3273,7 @@ pub mod root {
                 #[link_name = "_ZN2nn2fs17MountCacheStorageEPKc"]
                 pub fn MountCacheStorage(mount_point: *const libc::c_char) -> root::Result;
             }
-            pub fn MountCache<S: AsRef<str>>(mount_point: S) -> root::Result {
+            pub fn mount_cache_storage<S: AsRef<str>>(mount_point: S) -> root::Result {
                 unsafe {
                     MountCacheStorage([mount_point.as_ref(), "\0"].concat().as_ptr())
                 }


### PR DESCRIPTION
also adds a wrapper for it so you dont have to call unsafe code & so you dont have to append the "\0" when providing the mount point