### PR TITLE
Add ui2d helpers to TextBox

### DIFF
--- a/src/nn/ui2d.rs
+++ b/src/nn/ui2d.rs
@@ -206,6 +206,20 @@ pub enum TextBoxFlag {
     PerCharacterTransformSplitByCharWidthInsertSpaceEnabled,
 }
 
+pub enum HorizontalPosition {
+    Center,
+    Left,
+    Right,
+    MaxHorizontalPosition,
+}
+
+pub enum VerticalPosition {
+    Center,
+    Left,
+    Right,
+    MaxVerticalPosition,
+}
+
 #[repr(C)]
 #[derive(Debug, Copy, Clone)]
 pub struct TextBox {
@@ -301,6 +315,15 @@ impl TextBox {
         self.shadow_scale = scale;
         self.shadow_color = colors;
         self.shadow_italic_ratio = italic_ratio;
+    }
+
+    pub unsafe fn set_text_alingment(
+        &mut self,
+        horizontal: HorizontalPosition,
+        vertical: VerticalPosition,
+    ) {
+        self.text_position =
+            horizontal * HorizontalPosition::MaxHorizontalPosition + VerticalPosition;
     }
 }
 

--- a/src/nn/ui2d.rs
+++ b/src/nn/ui2d.rs
@@ -285,12 +285,29 @@ impl TextBox {
         match value {
             true => {
                 self.m_bits |= 1 << text_pane.m_bits =
-                    text_pane.m_bits & !(1 << TextBoxFlag::InvisibleBorderEnabled as u8);
+                    text_pane.m_bits & !(1 << TextBoxFlag::InvisibleBorderEnabled as u8)
             }
-            false => {
-                self.m_bits |= 1 << TextBoxFlag::InvisibleBorderEnabled as u8;
-            }
+
+            false => self.m_bits |= 1 << TextBoxFlag::InvisibleBorderEnabled as u8,
+
+            _ => {}
         }
+    }
+
+    pub unsafe fn set_text_shadow(
+        &mut self,
+        offset: ResVec2,
+        scale: ResVec2,
+        colors: [ResColor; 2],
+        italic_ratio: f32,
+    ) {
+        self.m_shadow_offset_x = offset.x;
+        self.m_shadow_offset_y = offset.y;
+        self.m_shadow_scale_x = scale.x;
+        self.m_shadow_scale_y = scale.y;
+        self.m_shadow_top_color = colors[0];
+        self.m_shadow_bottom_color = colors[1];
+        self.m_shadow_italic_ratio = italic_ratio;
     }
 }
 

--- a/src/nn/ui2d.rs
+++ b/src/nn/ui2d.rs
@@ -290,15 +290,15 @@ impl TextBox {
         self.set_material_black_color(0.0, 0.0, 0.0, 255.0);
     }
 
-    pub unsafe fn text_outline_enable(&mut self, value: bool) {
-        match value {
+    pub unsafe fn text_outline_enable(&mut self, enabled: bool) {
+        match enabled {
             true => self.bits &= !(1 << TextBoxFlag::InvisibleBorderEnabled as u8),
             false => self.bits |= 1 << TextBoxFlag::InvisibleBorderEnabled as u8,
         }
     }
 
     pub unsafe fn text_shadow_enable(&mut self, enabled: bool) {
-        match value {
+        match enabled {
             true => self.bits |= 1 << TextBoxFlag::ShadowEnabled as u8,
             false => self.bits &= !(1 << TextBoxFlag::ShadowEnabled as u8),
         }

--- a/src/nn/ui2d.rs
+++ b/src/nn/ui2d.rs
@@ -294,6 +294,19 @@ impl TextBox {
         }
     }
 
+    pub unsafe fn set_text_shadow_enabled(&mut self, value: bool) {
+        match value {
+            true => self.m_bits |= 1 << TextBoxFlag::ShadowEnabled as u8,
+
+            false => {
+                self.m_bits |= 1 << text_pane.m_bits =
+                    text_pane.m_bits & !(1 << TextBoxFlag::ShadowEnabled as u8)
+            }
+
+            _ => {}
+        }
+    }
+
     pub unsafe fn set_text_shadow(
         &mut self,
         offset: ResVec2,

--- a/src/nn/ui2d.rs
+++ b/src/nn/ui2d.rs
@@ -211,57 +211,52 @@ pub enum TextBoxFlag {
 pub struct TextBox {
     pub pane: Pane,
     // Actually a union
-    pub m_text_buf: *mut libc::c_char,
-    pub m_p_text_id: *const libc::c_char,
-    pub m_text_colors: [[u8; 4]; 2],
-    pub m_p_font: *const libc::c_void,
-    pub m_font_size_x: f32,
-    pub m_font_size_y: f32,
-    pub m_line_space: f32,
-    pub m_char_space: f32,
+    pub text_buf: *mut libc::c_char,
+    pub p_text_id: *const libc::c_char,
+    pub text_colors: [[u8; 4]; 2],
+    pub p_font: *const libc::c_void,
+    pub font_size_x: f32,
+    pub font_size_y: f32,
+    pub line_space: f32,
+    pub char_space: f32,
 
     // Actually a union
-    pub m_p_tag_processor: *const libc::c_char,
+    pub p_tag_processor: *const libc::c_char,
 
-    pub m_text_buf_len: u16,
-    pub m_text_len: u16,
+    pub text_buf_len: u16,
+    pub text_len: u16,
 
     // Use TextBoxFlag
-    pub m_bits: u16,
-    pub m_text_position: u8,
+    pub bits: u16,
+    pub text_position: u8,
 
-    pub m_is_utf8: bool,
+    pub is_utf8: bool,
 
-    pub m_italic_ratio: f32,
+    pub italic_ratio: f32,
 
-    pub m_shadow_offset_x: f32,
-    pub m_shadow_offset_y: f32,
-    pub m_shadow_scale_x: f32,
-    pub m_shadow_scale_y: f32,
-    pub m_shadow_top_color: [u8; 4],
-    pub m_shadow_bottom_color: [u8; 4],
-    pub m_shadow_italic_ratio: f32,
+    pub shadow_offset: ResVec2,
+    pub shadow_scale: ResVec2,
+    pub shadow_color: [ResColor; 2],
+    pub shadow_italic_ratio: f32,
 
-    pub m_p_line_width_offset: *const libc::c_void,
+    pub p_line_width_offset: *const libc::c_void,
 
-    pub m_p_material: *mut Material,
-    pub m_p_disp_string_buf: *const libc::c_void,
+    pub p_material: *mut Material,
+    pub p_disp_string_buf: *const libc::c_void,
 
-    pub m_p_per_character_transform: *const libc::c_void,
+    pub p_per_character_transform: *const libc::c_void,
 }
 
 impl TextBox {
     pub fn set_color(&mut self, r: u8, g: u8, b: u8, a: u8) {
         let input_color = [r, g, b, a];
         let mut dirty: bool = false;
-        self.m_text_colors
-            .iter_mut()
-            .for_each(|top_or_bottom_color| {
-                if *top_or_bottom_color != input_color {
-                    dirty = true;
-                }
-                *top_or_bottom_color = input_color;
-            });
+        self.text_colors.iter_mut().for_each(|top_or_bottom_color| {
+            if *top_or_bottom_color != input_color {
+                dirty = true;
+            }
+            *top_or_bottom_color = input_color;
+        });
 
         if dirty {
             self.m_bits |= 1 << TextBoxFlag::IsPTDirty as u8;
@@ -281,23 +276,17 @@ impl TextBox {
         self.set_material_black_color(0.0, 0.0, 0.0, 255.0);
     }
 
-    pub unsafe fn set_text_outline_enabled(&mut self, value: bool) {
+    pub unsafe fn text_outline_enable(&mut self, value: bool) {
         match value {
-            true => self.m_bits = self.m_bits & !(1 << TextBoxFlag::InvisibleBorderEnabled as u8),
-
-            false => self.m_bits |= 1 << TextBoxFlag::InvisibleBorderEnabled as u8,
-
-            _ => {}
+            true => self.bits &= !(1 << TextBoxFlag::InvisibleBorderEnabled as u8),
+            false => self.bits |= 1 << TextBoxFlag::InvisibleBorderEnabled as u8,
         }
     }
 
-    pub unsafe fn set_text_shadow_enabled(&mut self, value: bool) {
+    pub unsafe fn text_shadow_enable(&mut self, enabled: bool) {
         match value {
-            true => self.m_bits |= 1 << TextBoxFlag::ShadowEnabled as u8,
-
-            false => self.m_bits = self.m_bits & !(1 << TextBoxFlag::ShadowEnabled as u8),
-
-            _ => {}
+            true => self.bits |= 1 << TextBoxFlag::ShadowEnabled as u8,
+            false => self.bits &= !(1 << TextBoxFlag::ShadowEnabled as u8),
         }
     }
 
@@ -305,16 +294,13 @@ impl TextBox {
         &mut self,
         offset: ResVec2,
         scale: ResVec2,
-        colors: [[u8; 4]; 2],
+        colors: [ResColor; 2],
         italic_ratio: f32,
     ) {
-        self.m_shadow_offset_x = offset.x;
-        self.m_shadow_offset_y = offset.y;
-        self.m_shadow_scale_x = scale.x;
-        self.m_shadow_scale_y = scale.y;
-        self.m_shadow_top_color = colors[0];
-        self.m_shadow_bottom_color = colors[1];
-        self.m_shadow_italic_ratio = italic_ratio;
+        self.shadow_offset = offset;
+        self.shadow_scale = scale;
+        self.shadow_color = colors;
+        self.shadow_italic_ratio = italic_ratio;
     }
 }
 

--- a/src/nn/ui2d.rs
+++ b/src/nn/ui2d.rs
@@ -317,13 +317,13 @@ impl TextBox {
         self.shadow_italic_ratio = italic_ratio;
     }
 
-    pub unsafe fn set_text_alingment(
+    pub unsafe fn set_text_alignment(
         &mut self,
         horizontal: HorizontalPosition,
         vertical: VerticalPosition,
     ) {
         self.text_position =
-            horizontal * HorizontalPosition::MaxHorizontalPosition + VerticalPosition;
+            horizontal as u8 * HorizontalPosition::MaxHorizontalPosition as u8 + vertical as u8;
     }
 }
 

--- a/src/nn/ui2d.rs
+++ b/src/nn/ui2d.rs
@@ -259,16 +259,16 @@ impl TextBox {
         });
 
         if dirty {
-            self.m_bits |= 1 << TextBoxFlag::IsPTDirty as u8;
+            self.bits |= 1 << TextBoxFlag::IsPTDirty as u8;
         }
     }
 
     pub unsafe fn set_material_white_color(&mut self, r: f32, g: f32, b: f32, a: f32) {
-        (*self.m_p_material).set_white_color(r, g, b, a);
+        (*self.p_material).set_white_color(r, g, b, a);
     }
 
     pub unsafe fn set_material_black_color(&mut self, r: f32, g: f32, b: f32, a: f32) {
-        (*self.m_p_material).set_black_color(r, g, b, a);
+        (*self.p_material).set_black_color(r, g, b, a);
     }
 
     pub unsafe fn set_default_material_colors(&mut self) {

--- a/src/nn/ui2d.rs
+++ b/src/nn/ui2d.rs
@@ -283,10 +283,7 @@ impl TextBox {
 
     pub unsafe fn set_text_outline_enabled(&mut self, value: bool) {
         match value {
-            true => {
-                self.m_bits |= 1 << text_pane.m_bits =
-                    text_pane.m_bits & !(1 << TextBoxFlag::InvisibleBorderEnabled as u8)
-            }
+            true => self.m_bits = self.m_bits & !(1 << TextBoxFlag::InvisibleBorderEnabled as u8),
 
             false => self.m_bits |= 1 << TextBoxFlag::InvisibleBorderEnabled as u8,
 
@@ -298,10 +295,7 @@ impl TextBox {
         match value {
             true => self.m_bits |= 1 << TextBoxFlag::ShadowEnabled as u8,
 
-            false => {
-                self.m_bits |= 1 << text_pane.m_bits =
-                    text_pane.m_bits & !(1 << TextBoxFlag::ShadowEnabled as u8)
-            }
+            false => self.m_bits = self.m_bits & !(1 << TextBoxFlag::ShadowEnabled as u8),
 
             _ => {}
         }
@@ -311,7 +305,7 @@ impl TextBox {
         &mut self,
         offset: ResVec2,
         scale: ResVec2,
-        colors: [ResColor; 2],
+        colors: [[u8; 4]; 2],
         italic_ratio: f32,
     ) {
         self.m_shadow_offset_x = offset.x;

--- a/src/nn/ui2d.rs
+++ b/src/nn/ui2d.rs
@@ -203,7 +203,7 @@ pub enum TextBoxFlag {
     PerCharacterTransformOriginToCenter,
     PerCharacterTransformFixSpace,
     LinefeedByCharacterHeightEnabled,
-    PerCharacterTransformSplitByCharWidthInsertSpaceEnabled
+    PerCharacterTransformSplitByCharWidthInsertSpaceEnabled,
 }
 
 #[repr(C)]
@@ -279,6 +279,18 @@ impl TextBox {
     pub unsafe fn set_default_material_colors(&mut self) {
         self.set_material_white_color(255.0, 255.0, 255.0, 255.0);
         self.set_material_black_color(0.0, 0.0, 0.0, 255.0);
+    }
+
+    pub unsafe fn set_text_outline_enabled(&mut self, value: bool) {
+        match value {
+            true => {
+                self.m_bits |= 1 << text_pane.m_bits =
+                    text_pane.m_bits & !(1 << TextBoxFlag::InvisibleBorderEnabled as u8);
+            }
+            false => {
+                self.m_bits |= 1 << TextBoxFlag::InvisibleBorderEnabled as u8;
+            }
+        }
     }
 }
 
@@ -392,11 +404,21 @@ impl Material {
     }
 
     pub fn set_white_res_color(&mut self, white: ResColor) {
-        self.set_white_color(white.r as f32, white.g as f32, white.b as f32, white.a as f32);
+        self.set_white_color(
+            white.r as f32,
+            white.g as f32,
+            white.b as f32,
+            white.a as f32,
+        );
     }
 
     pub fn set_black_res_color(&mut self, black: ResColor) {
-        self.set_black_color(black.r as f32, black.g as f32, black.b as f32, black.a as f32);
+        self.set_black_color(
+            black.r as f32,
+            black.g as f32,
+            black.b as f32,
+            black.a as f32,
+        );
     }
 }
 

--- a/src/nn/ui2d.rs
+++ b/src/nn/ui2d.rs
@@ -215,8 +215,8 @@ pub enum HorizontalPosition {
 
 pub enum VerticalPosition {
     Center,
-    Left,
-    Right,
+    Top,
+    Bottom,
     MaxVerticalPosition,
 }
 

--- a/src/nn/ui2d.rs
+++ b/src/nn/ui2d.rs
@@ -290,21 +290,21 @@ impl TextBox {
         self.set_material_black_color(0.0, 0.0, 0.0, 255.0);
     }
 
-    pub unsafe fn text_outline_enable(&mut self, enabled: bool) {
+    pub fn text_outline_enable(&mut self, enabled: bool) {
         match enabled {
             true => self.bits &= !(1 << TextBoxFlag::InvisibleBorderEnabled as u8),
             false => self.bits |= 1 << TextBoxFlag::InvisibleBorderEnabled as u8,
         }
     }
 
-    pub unsafe fn text_shadow_enable(&mut self, enabled: bool) {
+    pub fn text_shadow_enable(&mut self, enabled: bool) {
         match enabled {
             true => self.bits |= 1 << TextBoxFlag::ShadowEnabled as u8,
             false => self.bits &= !(1 << TextBoxFlag::ShadowEnabled as u8),
         }
     }
 
-    pub unsafe fn set_text_shadow(
+    pub fn set_text_shadow(
         &mut self,
         offset: ResVec2,
         scale: ResVec2,
@@ -317,7 +317,7 @@ impl TextBox {
         self.shadow_italic_ratio = italic_ratio;
     }
 
-    pub unsafe fn set_text_alignment(
+    pub fn set_text_alignment(
         &mut self,
         horizontal: HorizontalPosition,
         vertical: VerticalPosition,


### PR DESCRIPTION
##Changes
1. Added the following functions to ui2d:
    - `TextBox.text_outline_enable()`
    - `TextBox.text_shadow_enable()`
    - `TextBox.set_text_shadow()`
    - `TextBox.set_text_alignment()`

2. Added the following enums:
    - `HorizontalPosition`
    - `VerticalPosition`
   
3. Refactored the TextBox struct to remove `m_` prefix from struct members