### PR TITLE
Update panel visibility logic

### DIFF
--- a/src/nn/ui2d.rs
+++ b/src/nn/ui2d.rs
@@ -121,8 +121,8 @@ impl Pane {
 
     pub unsafe fn set_visible(&mut self, visible: bool) {
         match visible {
-            true => self.bits |= 1 << PaneFlag::Visible as u8,
-            false => self.bits &= !(1 << PaneFlag::Visible as u8),
+            true => self.flags |= 1 << PaneFlag::Visible as u8,
+            false => self.flags &= !(1 << PaneFlag::Visible as u8),
         }
     }
 

--- a/src/nn/ui2d.rs
+++ b/src/nn/ui2d.rs
@@ -120,12 +120,9 @@ impl Pane {
     }
 
     pub unsafe fn set_visible(&mut self, visible: bool) {
-        if visible {
-            self.alpha = 255;
-            self.global_alpha = 255;
-        } else {
-            self.alpha = 0;
-            self.global_alpha = 0;
+        match visible {
+            true => self.bits |= 1 << PaneFlag::Visible as u8,
+            false => self.bits &= !(1 << PaneFlag::Visible as u8),
         }
     }
 


### PR DESCRIPTION
Updated the logic of `set_visible` to ensure that Pane visibility is properly toggled. Previously, the alpha of the pane was set, but this did not guarantee that it was set to be visible.