### PR TITLE
Update simd vectors again

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 #![feature(repr_simd)]
 #![feature(new_uninit)]
 #![feature(new_zeroed_alloc)]
+#![feature(core_intrinsics)]
 
 #[cfg(not(feature = "rustc-dep-of-std"))]
 extern crate alloc;

--- a/src/nn/util.rs
+++ b/src/nn/util.rs
@@ -1,11 +1,54 @@
+#[derive(Clone, Copy)]
 #[repr(simd)]
 pub struct Vector3f {
     pub value: [f32;3]
 }
 
+impl Vector3f {
+    pub fn x(self) -> f32 {
+        unsafe {
+            core::intrinsics::simd::simd_extract(self, 0)
+        }
+    }
+    pub fn y(self) -> f32 {
+        unsafe {
+            core::intrinsics::simd::simd_extract(self, 1)
+        }
+    }
+    pub fn z(self) -> f32 {
+        unsafe {
+            core::intrinsics::simd::simd_extract(self, 2)
+        }
+    }
+}
+
+#[derive(Clone, Copy)]
 #[repr(simd)]
 pub struct Vector4f {
     pub value: [f32;4]
+}
+
+impl Vector4f {
+    pub fn x(self) -> f32 {
+        unsafe {
+            core::intrinsics::simd::simd_extract(self, 0)
+        }
+    }
+    pub fn y(self) -> f32 {
+        unsafe {
+            core::intrinsics::simd::simd_extract(self, 1)
+        }
+    }
+    pub fn z(self) -> f32 {
+        unsafe {
+            core::intrinsics::simd::simd_extract(self, 2)
+        }
+    }
+    pub fn w(self) -> f32 {
+        unsafe {
+            core::intrinsics::simd::simd_extract(self, 3)
+        }
+    }
 }
 
 #[allow(unused_imports)]


### PR DESCRIPTION
The incoming cargo-skyline std update to Rust Nightly 1.95.0 (2.14.26) necessitates these changes to more easily get the values from simd vectors.

Not to be merged until the std is updated.